### PR TITLE
Add script to determine mapping types on all data/*

### DIFF
--- a/src/mapping_finder.py
+++ b/src/mapping_finder.py
@@ -155,6 +155,7 @@ def get_latex_trow(classification: Classification) -> str:
 LATEX_HEADER: Final[str] = "RE & ST & P & N & Prevalence ($\\%$) & $1{:}1$ & $1{:}M$ & $M{:}1$ & $N{:}M$ & Unassigned \\\\"
 
 
+# TODO: make the tables more pleasant to look at.
 def get_latex_table(dataset: str, data: list[Classification]) -> str:
     has_subsets = len(data) > 1
     return """


### PR DESCRIPTION
## Add script to determine mapping types on all data/*

+ Will take only one the full "dataset" for HW and BTHS.
+ Supports "LaTeX mode" that will only return format `val && val && val && val` suitable for a table environment.

Resolves #41